### PR TITLE
link to mobile SDK overhead measurement

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,6 @@ In this repository we keep testing environments and test cases for **Sentry SDK 
 
 ## Related Links
 
+* GitHub actions for Mobile SDK overhead measurements: https://github.com/getsentry/action-app-sdk-overhead-metrics
 * Previous iteration of similar idea: https://github.com/getsentry/sentry-sdk-benchmark
 * Overview of Sentry SDKs: https://develop.sentry.dev/sdk/overview/


### PR DESCRIPTION
The repo is named `sdk-measurement` which is quite generic. It doesn't cover Browser or Mobile, so adding a link to the repo we have with work done to measure overhead of mobile apps.

Idea: How about we rename this repo to `backend-sdk-measurements` ?